### PR TITLE
Update Gnome runtime-version from 43 to 45

### DIFF
--- a/io.posidon.Paper.json
+++ b/io.posidon.Paper.json
@@ -1,7 +1,7 @@
 {
     "app-id": "io.posidon.Paper",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "43",
+    "runtime-version": "45",
     "sdk": "org.gnome.Sdk",
     "command": "io.posidon.Paper",
     "finish-args": [


### PR DESCRIPTION
Gnome runtime-version 43 is end-of-life since September 20, 2023.